### PR TITLE
Support collision detection without cell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # ChangeLog
 
+## 3.0.3
+
+* セルの無いパーツについても `CircleCollider` が動作するように修正
+* セルの無いパーツについても `BoneCellCollider` が動作するように修正
+  * セルがない時、サイズが `(width, height) = (1.0, 1.0)` のセルと同等の判定になる
+
 ## 3.0.2
 
 * AlphaBlendModeを `@akashic-extension/akashic-animation` から読み込めるように修正

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic-extension/akashic-animation",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "A skeletal animation library for Akashic Engine",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/Actor.ts
+++ b/src/Actor.ts
@@ -602,18 +602,13 @@ class Actor extends g.E {
 }
 
 function createFinalizedCell(posture: Posture, skins: {[key: string]: Skin}): FinalizedCell {
-	if (posture === undefined) {
+	if (posture === undefined || posture.attrs[AttrId.cv] === undefined) {
 		return undefined;
 	}
 
 	const attrs = posture.attrs;
 
-	if (! attrs[AttrId.cv]) {
-		return undefined;
-	}
-
-	const skinName = attrs[AttrId.cv].skinName;
-	const skin = skins[skinName];
+	const skin = skins[attrs[AttrId.cv].skinName];
 	if (! skin) {
 		return undefined;
 	}

--- a/src/Actor.ts
+++ b/src/Actor.ts
@@ -582,7 +582,7 @@ class Actor extends g.E {
 		// | /    \
 		// |
 		// v
-		if (finalizedCell && finalizedCell.surface && finalizedCell.cell) {
+		if (finalizedCell) {
 			// ミックスはデフォルト値なので、αブレンドがミックスの場合はcomposite-operation指定処理を省略する
 			if (finalizedCell.alphaBlendMode !== undefined && finalizedCell.alphaBlendMode !== "normal") {
 				renderer.setCompositeOperation(getCompositeOperation(finalizedCell.alphaBlendMode));

--- a/src/Actor.ts
+++ b/src/Actor.ts
@@ -582,7 +582,7 @@ class Actor extends g.E {
 		// | /    \
 		// |
 		// v
-		if (finalizedCell) {
+		if (finalizedCell && finalizedCell.surface && finalizedCell.cell) {
 			// ミックスはデフォルト値なので、αブレンドがミックスの場合はcomposite-operation指定処理を省略する
 			if (finalizedCell.alphaBlendMode !== undefined && finalizedCell.alphaBlendMode !== "normal") {
 				renderer.setCompositeOperation(getCompositeOperation(finalizedCell.alphaBlendMode));
@@ -602,11 +602,23 @@ class Actor extends g.E {
 }
 
 function createFinalizedCell(posture: Posture, skins: {[key: string]: Skin}): FinalizedCell {
-	if (posture === undefined || posture.attrs[AttrId.cv] === undefined) {
+	if (posture === undefined) {
 		return undefined;
 	}
 
 	const attrs = posture.attrs;
+
+	if (! attrs[AttrId.cv]) {
+		// skin, cell が存在しないが、当たり判定のために計算する
+		const finalizedCell = new FinalizedCell();
+		finalizedCell.surface = undefined;
+		finalizedCell.cell = undefined;
+		finalizedCell.u = 0;
+		finalizedCell.v = 0;
+		finalizedCell.matrix = new g.PlainMatrix();
+		finalizedCell.alphaBlendMode = posture.alphaBlendMode;
+		return finalizedCell;
+	}
 
 	const skinName = attrs[AttrId.cv].skinName;
 	const skin = skins[skinName];

--- a/src/Actor.ts
+++ b/src/Actor.ts
@@ -609,15 +609,7 @@ function createFinalizedCell(posture: Posture, skins: {[key: string]: Skin}): Fi
 	const attrs = posture.attrs;
 
 	if (! attrs[AttrId.cv]) {
-		// skin, cell が存在しないが、当たり判定のために計算する
-		const finalizedCell = new FinalizedCell();
-		finalizedCell.surface = undefined;
-		finalizedCell.cell = undefined;
-		finalizedCell.u = 0;
-		finalizedCell.v = 0;
-		finalizedCell.matrix = new g.PlainMatrix();
-		finalizedCell.alphaBlendMode = posture.alphaBlendMode;
-		return finalizedCell;
+		return undefined;
 	}
 
 	const skinName = attrs[AttrId.cv].skinName;

--- a/src/CellAttachmentCollider.ts
+++ b/src/CellAttachmentCollider.ts
@@ -34,33 +34,35 @@ class CellAttachmentCollider extends Collider {
 			return undefined;
 		}
 
-		if (this.dirty) {
-			this.dirty = false;
-			if (! this._volume) {
-				// 以下は静的な値であるとみなす
-				this._volume = new BoxVolume();
-				this._volume.matrix = new g.PlainMatrix();
-				this._volume.origin.x = 0;
-				this._volume.origin.y = 0;
-				this._volume.size.width = this.cellAttachment.cell.size.width;
-				this._volume.size.height = this.cellAttachment.cell.size.height;
-			}
-
-			this._volume.aabbFirst = this.aabbFirst;
-
-			const m: number[] = [].concat(this.cellAttachment.posture.m._matrix);
-			if (this.cellAttachment.matrix) {
-				multiply(m, this.cellAttachment.matrix._matrix);
-			}
-			if (this.cellAttachment.pivotTransform) {
-				multiply(m, this.cellAttachment.pivotTransform);
-			}
-			// 矩形の位置を変えない鏡像のマトリクスなので無用
-			// multiply(m, this.cellAttachment.mirrorTransform);
-
-			this._volume.matrix._matrix = <[number, number, number, number, number, number]>m;
-			this._volume.dirty = true; // trigger to update aabb
+		if (! this.dirty) {
+			return this._volume;
 		}
+
+		this.dirty = false;
+		if (! this._volume) {
+			// 以下は静的な値であるとみなす
+			this._volume = new BoxVolume();
+			this._volume.matrix = new g.PlainMatrix();
+			this._volume.origin.x = 0;
+			this._volume.origin.y = 0;
+			this._volume.size.width = this.cellAttachment.cell.size.width;
+			this._volume.size.height = this.cellAttachment.cell.size.height;
+		}
+
+		this._volume.aabbFirst = this.aabbFirst;
+
+		const m: number[] = [].concat(this.cellAttachment.posture.m._matrix);
+		if (this.cellAttachment.matrix) {
+			multiply(m, this.cellAttachment.matrix._matrix);
+		}
+		if (this.cellAttachment.pivotTransform) {
+			multiply(m, this.cellAttachment.pivotTransform);
+		}
+		// 矩形の位置を変えない鏡像のマトリクスなので無用
+		// multiply(m, this.cellAttachment.mirrorTransform);
+
+		this._volume.matrix._matrix = <[number, number, number, number, number, number]>m;
+		this._volume.dirty = true; // trigger to update aabb
 
 		return this._volume;
 	}

--- a/src/CellAttachmentCollider.ts
+++ b/src/CellAttachmentCollider.ts
@@ -58,8 +58,10 @@ class CellAttachmentCollider extends Collider {
 		if (this.cellAttachment.pivotTransform) {
 			multiply(m, this.cellAttachment.pivotTransform);
 		}
-		// 矩形の位置を変えない鏡像のマトリクスなので無用
-		// multiply(m, this.cellAttachment.mirrorTransform);
+
+		// this.cellAttachment.mirrorTransform は鏡像の行列であり、
+		// 矩形の位置・形を変えない。当たり判定に際しては影響を持たない
+		// ので `m` に対して乗算しない。
 
 		this._volume.matrix._matrix = <[number, number, number, number, number, number]>m;
 		this._volume.dirty = true; // trigger to update aabb

--- a/src/CircleCollider.ts
+++ b/src/CircleCollider.ts
@@ -49,7 +49,8 @@ class CircleCollider extends Collider {
 	}
 
 	getVolume(): CircleVolume {
-		if (! this.enabled || ! this._posture.finalizedCell || ! this._posture.attrs[AttrId.visibility]) {
+		// 2018/06/21: cellを持たないpostureでの当たり判定をサポート
+		if (! this.enabled || ! this._posture.attrs[AttrId.visibility]) {
 			return undefined;
 		}
 


### PR DESCRIPTION
当たり判定について以下の修正を行います:
1. セルが存在しない時円形の当たり判定が利用できなかった問題の修正
2. セルが存在しない時 1x1 の正方形のセルが存在するとしてセル当たり判定を行うよう修正

TODO:
* [x] 各種サンプルでの動作確認
* [x] README.md 更新
* [x] CHANGELOG.md 更新
* [x] package.json 更新