### PR TITLE
Add comment on load project limitation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased changes
 
-* `Resource#loadProject()` がすでにロード済みのプロジェクトがあるときそれをResourceインスタンスから削除することをコメントに明記。
+* すでにプロジェクトをロード済みのリソースに対して`Resource#loadProject()`を実行すると以前ロードされた情報は削除されることをコメントに追加。
 
 ## 3.0.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # ChangeLog
 
+## Unreleased changes
+
+* `Resource#loadProject()` がすでにロード済みのプロジェクトがあるときそれをResourceインスタンスから削除することをコメントに明記。
+
 ## 3.0.3
 
 * セルの無いパーツについても `CircleCollider` が動作するように修正

--- a/src/Resource.ts
+++ b/src/Resource.ts
@@ -97,7 +97,9 @@ class Resource {
 	}
 
 	/**
-	 * asapjテキストアセットを読み込み、さらに関連するアセットも読み込む
+	 * asapjテキストアセットを読み込み、さらに関連するアセットも読み込む。
+	 *
+	 * すでに読み込んだaapjテキストアセットがあった場合、このResourceインスタンスから削除される。
 	 *
 	 * @param assetName asapjテキストアセット名
 	 * @param assets 利用できるアセット


### PR DESCRIPTION
すでにプロジェクトをロード済みのリソースに対して`Resource#loadProject()`を実行すると以前のリソースへの参照を失う制限について明記しました