### PR TITLE
delete peaceiris/actions-gh-pages from deploy_docs.yml

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -8,11 +8,10 @@ on:
 env:
   NODE_VERSION: 24
 
-permissions:
-  contents: write
-
 jobs:
-  deploy:
+  build:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -28,7 +27,21 @@ jobs:
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           npm ci
           npm run doc
-      - uses: peaceiris/actions-gh-pages@373f7f263a76c20808c831209c920827a82a2847 # v3.9.3
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./public
+          path: ./public
+
+  deploy:
+    needs: build
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5


### PR DESCRIPTION
### やったこと
ドキュメントページのデプロイワークフローでサードパーティーアクションの`peaceiris/actions-gh-pages`を利用せずに、デプロイ処理ができるように

### その他
- この修正は[Github公式マニュアル](https://docs.github.com/ja/pages/getting-started-with-github-pages/using-custom-workflows-with-github-pages)で公開されているGithubPagesサイト構築方法を参考にしています
- この変更でGithubPagesへの成果物はgh-pagesにpushされなくなります

### このPRのマージ後に必要な対応
- GithubリポジトリのGithubPageの設定で、デプロイ方法を「Deploy from a branch」から「Github Actions」に変更する